### PR TITLE
Give a value to n.genes slot of GenerateGenesets' output 

### DIFF
--- a/R/Genesets.R
+++ b/R/Genesets.R
@@ -51,9 +51,9 @@ GenerateGenesets <- function(x, perform.reversal = FALSE) {
     stop('perform.reversal must be TRUE or FALSE.')
   }
   # --- Code ---
-  ### Mode.
+  # Mode.
   mode <- c("up", "down")[c(n.up != 0, n.down != 0)]
-  ### Genes.
+  # Genes.
   unique.gene.sets <- unique(gsub(pattern = "_UP$|_DOWN$|_DN$", replacement = "",
                                   x = names(gmt.file), ignore.case = TRUE))
   genes <- setNames(lapply(unique.gene.sets, function(sig) {
@@ -74,10 +74,11 @@ GenerateGenesets <- function(x, perform.reversal = FALSE) {
     }
     return(l)
   }), unique.gene.sets)
-
+  # Median number of genes in all signatures.
+  n.genes <- median(sapply(genes, FUN = function(x) length(unlist(x))))
   # Output.
   return(geneset(genelist = genes,
-  n.genes = NaN, # User defined genesets have no n.genes
+  n.genes = n.genes,
   mode = mode,
   info = data.frame(), # User defined genesets have an empty info. slot.
   inverse.score = perform.reversal))


### PR DESCRIPTION
The current value is `NaN`, though the actual value should be a real number in order to compute the background matrix if necessary. With this commit, the value is now computed as the median number of genes per signature in the input gmt.